### PR TITLE
Implemented navigation to 'add ingredients' screen

### DIFF
--- a/app/src/main/java/com/example/fit5046a4/AddIngredientsScreen.kt
+++ b/app/src/main/java/com/example/fit5046a4/AddIngredientsScreen.kt
@@ -7,6 +7,7 @@ import androidx.annotation.RequiresApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -68,6 +69,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -89,7 +93,7 @@ import java.util.Locale
 @RequiresApi(Build.VERSION_CODES.O)
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AddIngredientsToDB(viewModel: IngredientViewModel) {
+fun AddIngredientsToDB(viewModel: IngredientViewModel, navController: NavController) {
     val ingredients by viewModel.allIngredients.collectAsState(initial = emptyList())
     var name by remember { mutableStateOf("") }
     var quantity by remember { mutableStateOf("") }
@@ -99,9 +103,20 @@ fun AddIngredientsToDB(viewModel: IngredientViewModel) {
     //var selectedIngredient by remember { mutableStateOf<Ingredient?>(null) }
     var category by remember { mutableStateOf("") }
     val context = LocalContext.current
+    val focusManager = LocalFocusManager.current
 
-    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-        Text("Ingredient:")
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            // When user taps away from the field, they keyboard disappears unless relevent field is tapped
+            .pointerInput(Unit) {
+                detectTapGestures(onTap = {
+                    focusManager.clearFocus()
+                })
+            },
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ){
+        Text("Ingredient:", fontSize = 16.sp, fontWeight = FontWeight.Medium)
         TextField(
             value = name,
             onValueChange = { name = it },
@@ -121,7 +136,7 @@ fun AddIngredientsToDB(viewModel: IngredientViewModel) {
         //Accepts input from a numerical keyboard only
         //To enable on emulator, go to settings, disable stylus input
         //and enable on screen keyboard
-        Text("Quantity & Unit:")
+        Text("Quantity & Unit:",fontSize = 15.sp, fontWeight = FontWeight.Medium)
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp)
@@ -129,7 +144,7 @@ fun AddIngredientsToDB(viewModel: IngredientViewModel) {
             TextField(
                 value = quantity,
                 onValueChange = { quantity = it },
-                placeholder = { Text("select qty") },
+                placeholder = { Text("select qty", fontSize = 14.sp) },
 
                 //numerical keyboarc
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
@@ -157,36 +172,40 @@ fun AddIngredientsToDB(viewModel: IngredientViewModel) {
         //Accepts input from a numerical keyboard only
         //To enable on emulator, go to settings, disable stylus input
         //and enable on screen keyboard
-        Text("Unit Price:")
-        TextField(
-            value = unitPrice,
-            onValueChange = { unitPrice = it },
-            placeholder = { Text("e.g. 2.50") },
+        Text("Unit Price & Category:", fontSize = 15.sp, fontWeight = FontWeight.Medium)
+        Row(
+            modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            TextField(
+                value = unitPrice,
+                onValueChange = { unitPrice = it },
+                placeholder = { Text("e.g. 2.50" ,fontSize = 14.sp) },
 
-            //numerical keyboard
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-            modifier = Modifier
-                .fillMaxWidth()
-                .clip(RoundedCornerShape(10.dp)),
-            singleLine = true,
-            shape = RoundedCornerShape(10.dp),
+                //numerical keyboard
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier
+                    .weight(1f)
+                    .clip(RoundedCornerShape(10.dp)),
+                singleLine = true,
+                shape = RoundedCornerShape(10.dp),
 
-            // when user clicks on the textfield, it changes colour to indicate click
-            colors = TextFieldDefaults.colors(
-                focusedContainerColor = Color(0xFFD7DEFB).copy(alpha = 0.6f),
-                unfocusedContainerColor = Color(0xFFD7DEFB).copy(alpha = 0.2f)
+                // when user clicks on the textfield, it changes colour to indicate click
+                colors = TextFieldDefaults.colors(
+                    focusedContainerColor = Color(0xFFD7DEFB).copy(alpha = 0.6f),
+                    unfocusedContainerColor = Color(0xFFD7DEFB).copy(alpha = 0.2f)
 
+                )
             )
-        )
 
-        Text("Category:", modifier = Modifier.padding(top = 12.dp))
+            CategoryDropDown(
+                selectedCategory = category,
+                onCategorySelected = { category = it },
+                modifier = Modifier.weight((1f))
+            )
 
-        CategoryDropDown(
-            selectedCategory = category,
-            onCategorySelected = { category = it }
-        )
+        }
 
-        Text("Expiry Date:", modifier = Modifier.padding(top = 12.dp))
+        Text("Expiry Date:", modifier = Modifier.padding(top = 4.dp), fontSize = 15.sp, fontWeight = FontWeight.Medium)
 
         //ExpiryDatePickerField() is called here so a calender is displayed
         //User selects expiry date on the calender date-picker pop-up
@@ -195,9 +214,7 @@ fun AddIngredientsToDB(viewModel: IngredientViewModel) {
             onDateSelected = { expiryDateText = it }
         )
 
-
-
-        Spacer(modifier = Modifier.height(10.dp))
+        Spacer(modifier = Modifier.height(24.dp))
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.Center
@@ -245,7 +262,12 @@ fun AddIngredientsToDB(viewModel: IngredientViewModel) {
             ElevatedButton(
                 onClick = {
                     name = ""; quantity = ""; unit = ""; unitPrice = ""; expiryDateText = ""; category = ""
-                    Toast.makeText(context, "Cancelled! Redirecting to fridge...", Toast.LENGTH_SHORT).show()
+                    //navigates user back to fridge screen upon cancellation
+                    navController.navigate("fridge"){
+                        popUpTo("add_ingredient"){
+                            inclusive = true
+                        }
+                    }
                 },
                 shape = RoundedCornerShape(12.dp),
             ) {
@@ -304,12 +326,11 @@ fun AddIngredientScreen(navController: NavController) {
                 )
             }
             item {
-                AddIngredientsToDB(viewModel = viewModel())
+                AddIngredientsToDB(viewModel = viewModel(), navController = navController)
             }
         }
 
     }
-
 
 //This function will have unit as a drop down menu
 //This will be called into the AddIngredientsToDB() function
@@ -337,7 +358,7 @@ fun UnitDropDown(
             readOnly = true,
             value = selectedUnit,
             onValueChange = {},
-            label = { Text("select unit") },
+            label = { Text("select unit", fontSize = 14.sp) },
 
             ////When user clicks on the textfield, it changes colour to indicate click
             colors = TextFieldDefaults.colors(
@@ -376,7 +397,6 @@ fun UnitDropDown(
 //This will be called into the AddIngredientsToDB() function
 //Week3 lab content
 //parameter logic similar to UnitDropDown function
-
 @RequiresApi(Build.VERSION_CODES.O)
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -398,7 +418,7 @@ fun ExpiryDatePickerField(
         value = expiryDate,
         onValueChange = {},
         readOnly = true,
-        label = { Text("select date") },
+        label = { Text("select date", fontSize = 14.sp) },
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(10.dp))
@@ -475,7 +495,7 @@ fun CategoryDropDown(
             readOnly = true,
             value = selectedCategory,
             onValueChange = {},
-            label = { Text("select category") },
+            label = { Text("select category", fontSize = 14.sp) },
 
             ////When user clicks on the textfield, it changes colour to indicate click
             colors = TextFieldDefaults.colors(
@@ -514,5 +534,3 @@ fun CategoryDropDown(
 //    AddIngredientScreen()
 //}
 //
-
-

--- a/app/src/main/java/com/example/fit5046a4/AddIngredientsScreen.kt
+++ b/app/src/main/java/com/example/fit5046a4/AddIngredientsScreen.kt
@@ -71,6 +71,7 @@ import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
 import com.example.fit5046a4.database.Ingredient
 import java.text.SimpleDateFormat
 import java.time.Instant
@@ -256,36 +257,37 @@ fun AddIngredientsToDB(viewModel: IngredientViewModel) {
 }
 
 //This function is the Screen when user clicks 'Add Ingredients'
-//in the Fridge Screen
-//TO DO: NAV ROUTE IN FRIDGE SCREEN
+// It is navigated to from the Fridge screen when the user clicks "Add Ingredient".
+// The navController parameter is passed in to allow navigation actions.
 @RequiresApi(Build.VERSION_CODES.O)
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AddIngredientScreen() {
+fun AddIngredientScreen(navController: NavController) {
+    //TEMPORARY COMMENT OUT: currently using BottomNavigationBarAndTopBar scaffold
     //Layout of the screen with grocery image
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth(),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Text(text = "Add Ingredients")
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = Color(0xFFD7DEFB),
-                    titleContentColor = MaterialTheme.colorScheme.primary,
-                )
-            )
-        }
-    ) { innerPadding ->
+//    Scaffold(
+//        topBar = {
+//            TopAppBar(
+//                title = {
+//                    Box(
+//                        modifier = Modifier
+//                            .fillMaxWidth(),
+//                        contentAlignment = Alignment.Center
+//                    ) {
+//                        Text(text = "Add Ingredients")
+//                    }
+//                },
+//                colors = TopAppBarDefaults.topAppBarColors(
+//                    containerColor = Color(0xFFD7DEFB),
+//                    titleContentColor = MaterialTheme.colorScheme.primary,
+//                )
+//            )
+//        }
+//    ) { innerPadding ->
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding)
+                //.padding(innerPadding)
                 .padding(horizontal = 24.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
@@ -307,7 +309,7 @@ fun AddIngredientScreen() {
         }
 
     }
-}
+
 
 //This function will have unit as a drop down menu
 //This will be called into the AddIngredientsToDB() function

--- a/app/src/main/java/com/example/fit5046a4/BottomNavigationBarAndTopBar.kt
+++ b/app/src/main/java/com/example/fit5046a4/BottomNavigationBarAndTopBar.kt
@@ -1,5 +1,7 @@
 package com.example.fit5046a4
 //noinspection UsingMaterialAndMaterial3Libraries
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.BottomNavigation
 //noinspection UsingMaterialAndMaterial3Libraries
@@ -23,6 +25,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 
+@RequiresApi(Build.VERSION_CODES.O)
 @OptIn(ExperimentalMaterial3Api::class)
 @Preview(showBackground = true)
 @Composable
@@ -49,6 +52,7 @@ fun BottomNavigationBarAndTopBar() {
                             "fridge" -> "My Fridge"
                             "cook" -> "Cook a Meal"
                             "report" -> "Report"
+                            "add_ingredient" -> "Add Ingredients"
                             else -> ""
                         },
                         style = MaterialTheme.typography.titleLarge
@@ -100,8 +104,16 @@ fun BottomNavigationBarAndTopBar() {
         ) {
             composable("home") { Home() }
             composable("cook") { Cook() }
-            composable("fridge") { Fridge() }
+            //Fridge screen receives navController to allow for internal in-screen navigation.
+            //Specifically, the "Add Ingredient" button inside the Fridge screen uses it to navigate to the Add Ingredient screen.
+            composable("fridge") { Fridge(navController) }
             composable("report") { Report() }
+
+            composable("add_ingredient") {
+                //This route handles navigation to the Add Ingredient screen.
+                //It is not part of the bottom navigation bar used for internal flow only, triggered from the Fridge screen.
+                AddIngredientScreen(navController)
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/fit5046a4/Fridge.kt
+++ b/app/src/main/java/com/example/fit5046a4/Fridge.kt
@@ -2,7 +2,9 @@ package com.example.fit5046a4
 
 
 import android.app.Application
+import android.os.Build
 import android.widget.Toast
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -43,9 +45,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
 
 
 //This was the UI implementation for Fridge
@@ -135,7 +139,35 @@ fun FridgeItemList(viewModel: IngredientViewModel = viewModel()) {
 
     //If Ingredients isn't empty, it will be displayed in lazy Column
     if (ingredients.isEmpty()) {
-        Text("Your fridge is currently empty! Add Ingredients below")
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp)
+        ) {
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 4.dp),
+                shape = RoundedCornerShape(8.dp),
+                tonalElevation = 2.dp,
+                color = Color(0xFFD7DEFB).copy(alpha = 0.2f)
+            ) {
+                Row(
+                    modifier = Modifier
+                        .padding(10.dp),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = "Your fridge is currently empty! \nAdd ingredients below.",
+                        style = MaterialTheme.typography.bodyLarge,
+                        textAlign = TextAlign.Center,
+                        //color = Color(0xFF888888)
+                        color = Color(0xFF495D92)
+                    )
+                }
+            }
+        }
     } else {
         Box(
             modifier = Modifier
@@ -189,8 +221,9 @@ fun FridgeItemList(viewModel: IngredientViewModel = viewModel()) {
 //This is the Fridge function that lays out the components
 //The first component will be the FridgeItemList
 //The second component will be the AddIngredients Function
+//navController is passed in to allow navigation from inside this screen (e.g., to "add_ingredient")
 @Composable
-fun Fridge() {
+fun Fridge(navController: NavController) {
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -207,7 +240,14 @@ fun Fridge() {
         Spacer(modifier = Modifier.height(50.dp))
         Text("Here's what you've got right now:", fontSize = 20.sp)
         Spacer(modifier = Modifier.height(30.dp))
+
+        //displays fridge items from database
         FridgeItemList()
+
+        Spacer(modifier = Modifier.height(30.dp))
+
+        //displays button to add ingredients
+        AddIngredientsButton(navController)
     }
 }
 
@@ -217,10 +257,23 @@ fun EditIngredients(){
     Text("TO DO")
 }
 
-//This is the function to AddIngredients
+//This is the function to Add Ingredients
+//Upon clicking this button, user will be navigated to the AddIngredientScreen
 @Composable
-fun AddIngredients(){
-    Text("TO DO")
+fun AddIngredientsButton(navController: NavController){
+    val context = LocalContext.current
+    ElevatedButton(
+        onClick = {
+            navController.navigate("add_ingredient")
+        },
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Icon(
+            imageVector = Icons.Default.Add,
+            contentDescription = "Add",
+            modifier = Modifier.padding(end = 8.dp)
+        )
+        Text(text="Add Ingredients")
+    }
 }
-
 

--- a/app/src/main/java/com/example/fit5046a4/MainActivity.kt
+++ b/app/src/main/java/com/example/fit5046a4/MainActivity.kt
@@ -1,9 +1,11 @@
 package com.example.fit5046a4
 
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -26,6 +28,7 @@ import com.example.fit5046a4.ui.theme.FIT5046A4Theme
 import java.util.stream.DoubleStream.builder
 
 class MainActivity : ComponentActivity() {
+    @RequiresApi(Build.VERSION_CODES.O)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -45,6 +48,7 @@ class MainActivity : ComponentActivity() {
 //    )
 //}
 
+@RequiresApi(Build.VERSION_CODES.O)
 @Preview(showBackground = true)
 @Composable
 fun GreetingPreview() {


### PR DESCRIPTION
This PR allows the navigation of 'add ingredients/items page' when user clicks it from the fridge screen.

Details:

-- We still uses scaffold from BottomNavigationBarAndTopBar() as it is called to run on main activity
-- Added necessary imports
-- Added 'Add Ingredients' label to the scaffold to BottomNavigationBarAndTopBar(), hence temporarily removed the default scaffold in original AddIngredientScreen() function
-- Added navcontroller on AddIngredientScreen() and Fridge() function to enable internal navigation
--Formatted some UI of code