### PR TITLE
Restrict quantity updates to prevent overstatement of purchases

### DIFF
--- a/app/src/main/java/com/example/fit5046a4/MainActivity.kt
+++ b/app/src/main/java/com/example/fit5046a4/MainActivity.kt
@@ -140,11 +140,11 @@ fun scheduleFridgeWorker(context: Context) {
 //    )
 //}
 
-@RequiresApi(Build.VERSION_CODES.O)
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    FIT5046A4Theme {
-        BottomNavigationBarAndTopBar()
-    }
-}
+//@RequiresApi(Build.VERSION_CODES.O)
+//@Preview(showBackground = true)
+//@Composable
+//fun GreetingPreview() {
+//    FIT5046A4Theme {
+//        BottomNavigationBarAndTopBar()
+//    }
+//}


### PR DESCRIPTION
- Added logic to prevent increasing quantity beyond original (normalized by unit)
- Displayed friendly guidance: “🛒 Want to add more? Use Add Items to reflect purchases. This feature only reduces quantity.”
- Improved UX to ensure fridge value and grocery spend reports remain accurate
- Restricted unit editing to compatible types (e.g., g/kg, ml/L, pcs/cups)